### PR TITLE
Fix reading hdf5 Files

### DIFF
--- a/Evaluation/loadFun.py
+++ b/Evaluation/loadFun.py
@@ -23,7 +23,7 @@ def loadmat(filename):
         # 访问MAT文件中的数据
         dataset = mat_file['img4ranking']
         print("MAT file opened successfully using scipy.io.loadmat.")
-    except NotImplementedError:
+    except NotImplementedError, ValueError:
         try:
             # 尝试使用h5py打开MAT文件
             with h5py.File(filename, 'r') as f:


### PR DESCRIPTION
Switch to using h5py if the .mat file is not a valid matlab file. 

If the file is written using h5py, scipy.loadmat will fail with  
`ValueError('Unknown mat file type, version 0, 0')
`
If we  catch this and use h5py to load the data (as already done for v7.3 data), we can use h5py to write the file.